### PR TITLE
[SASS-11975] update correlationId to match format, handle HIP error response and change to basic auth

### DIFF
--- a/app/connectors/HipConnector.scala
+++ b/app/connectors/HipConnector.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames}
+import uk.gov.hmrc.http.HeaderNames
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.util.UUID
@@ -24,13 +24,14 @@ import java.util.UUID
 trait HipConnector {
 
   val config: ServicesConfig
-
   val hipBaseUrl: String = config.baseUrl("hip")
-  val hipAuthToken: String = config.getString("microservice.services.hip.authorisation-token")
 
-  def hipHeaders(implicit hc: HeaderCarrier): Seq[(String, String)] = Seq(
-    "correlationId" -> hc.requestId.fold(UUID.randomUUID().toString)(_.value),
-    HeaderNames.authorisation -> s"Bearer $hipAuthToken"
+  private val hipAuthToken: String = config.getString("microservice.services.hip.authorisation-token")
+  private val hipAuthType: String = config.getString("microservice.services.hip.authType")
+
+  def hipHeaders: Seq[(String, String)] = Seq(
+    "correlationId" -> UUID.randomUUID().toString,
+    HeaderNames.authorisation -> s"$hipAuthType $hipAuthToken"
   )
 
 }

--- a/app/connectors/httpParsers/CreateIncomeSourcesHttpParser.scala
+++ b/app/connectors/httpParsers/CreateIncomeSourcesHttpParser.scala
@@ -30,6 +30,8 @@ object CreateIncomeSourcesHttpParser extends APIParser with Logging {
     override def read(method: String, url: String, response: HttpResponse): CreateIncomeSourcesResponse = {
       response.header("CorrelationId").foreach(MDC.put("CorrelationId", _))
 
+      logger.debug(s"[CreateIncomeSourcesHttpReads] Response body: ${response.body}")
+
       response.status match {
         case OK =>
           response.json.validate[IncomeSourceIdModel].fold(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -120,6 +120,7 @@ microservice {
         host = "localhost"
         port = 9303
         authorisation-token = "clientId:secret"
+        authType = "Basic"
     }
   }
 }

--- a/it/test/connectors/CreateIncomeSourcesConnectorISpec.scala
+++ b/it/test/connectors/CreateIncomeSourcesConnectorISpec.scala
@@ -26,7 +26,7 @@ import play.api.Configuration
 import play.api.http.Status._
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.test.{HttpClientV2Support, WireMockSupport}
-import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames, RequestId}
+import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -40,17 +40,20 @@ class CreateIncomeSourcesConnectorISpec
     with HttpClientV2Support
     with EitherValues {
 
-  private val hipAuthToken = "Bearer test-token"
+  private val hipAuthToken = "Basic test-token"
+  val correlationIdRegex = "^[0-9a-fA-F]{8}[-][0-9a-fA-F]{4}[-][0-9a-fA-F]{4}[-][0-9a-fA-F]{4}[-][0-9a-fA-F]{12}$"
 
   private val servicesConfig = new ServicesConfig(Configuration.from(Map(
     "microservice.services.hip.protocol" -> "http",
     "microservice.services.hip.host" -> wireMockHost,
     "microservice.services.hip.port" -> wireMockPort,
-    "microservice.services.hip.authorisation-token" -> "test-token"
+    "microservice.services.hip.authorisation-token" -> "test-token",
+    "microservice.services.hip.authType" -> "Basic"
   )))
 
   val connector = new CreateIncomeSourceConnectorImpl(httpClientV2, servicesConfig)
 
+  implicit val hc: HeaderCarrier = HeaderCarrier()
   val nino = "nino"
   val url = s"/itsd/income-sources/$nino"
 
@@ -64,25 +67,22 @@ class CreateIncomeSourcesConnectorISpec
     "when the response is 200" - {
       "when the response body can be parsed" - {
         "return the incomeSourceId include internal headers" in {
-          val requestId = RequestId("request-id-value")
-          val hc = HeaderCarrier(requestId = Some(requestId))
 
           val expectedResponse = IncomeSourceIdModel("income-source-id-value")
 
           stubFor(
             post(urlEqualTo(url))
               .withRequestBody(equalToJson(Json.toJson(model).toString))
-              .withHeader("correlationId", equalTo(requestId.value))
+              .withHeader("correlationId", matching(correlationIdRegex))
               .withHeader(HeaderNames.authorisation, equalTo(hipAuthToken))
               .willReturn(
                 aResponse()
                   .withStatus(OK)
-                  .withHeader("correlationId", requestId.value)
                   .withBody(Json.toJson(expectedResponse).toString)
               )
           )
 
-          val result = connector.createIncomeSource(nino, model)(hc).futureValue
+          val result = connector.createIncomeSource(nino, model).futureValue
 
           result.value shouldEqual expectedResponse
         }
@@ -90,23 +90,20 @@ class CreateIncomeSourcesConnectorISpec
 
       "when the response body cannot be parsed" - {
         "return an error" in {
-          val requestId = RequestId("request-id-value")
-          val hc = HeaderCarrier(requestId = Some(requestId))
 
           stubFor(
             post(urlEqualTo(url))
               .withRequestBody(equalToJson(Json.toJson(model).toString))
-              .withHeader("correlationId", equalTo(requestId.value))
+              .withHeader("correlationId", matching(correlationIdRegex))
               .withHeader(HeaderNames.authorisation, equalTo(hipAuthToken))
               .willReturn(
                 aResponse()
                   .withStatus(OK)
-                  .withHeader("correlationId", requestId.value)
                   .withBody(Json.obj("key" -> "value").toString)
               )
           )
 
-          val result = connector.createIncomeSource(nino, model)(hc).futureValue
+          val result = connector.createIncomeSource(nino, model).futureValue
 
           result.left.value.status shouldBe 500
         }
@@ -115,23 +112,20 @@ class CreateIncomeSourcesConnectorISpec
 
     "when the response is 400" - {
       "return an error" in {
-        val requestId = RequestId("request-id-value")
-        val hc = HeaderCarrier(requestId = Some(requestId))
 
         stubFor(
           post(urlEqualTo(url))
             .withRequestBody(equalToJson(Json.toJson(model).toString))
-            .withHeader("correlationId", equalTo(requestId.value))
+            .withHeader("correlationId", matching(correlationIdRegex))
             .withHeader(HeaderNames.authorisation, equalTo(hipAuthToken))
             .willReturn(
               aResponse()
                 .withStatus(BAD_REQUEST)
-                .withHeader("correlationId", requestId.value)
                 .withBody(Json.obj("key" -> "value").toString)
             )
         )
 
-        val result = connector.createIncomeSource(nino, model)(hc).futureValue
+        val result = connector.createIncomeSource(nino, model).futureValue
 
         result.left.value.status shouldBe 500
       }
@@ -139,45 +133,39 @@ class CreateIncomeSourcesConnectorISpec
 
     "when the response is 500" - {
       "return an error when the error message can be parsed" in {
-        val requestId = RequestId("request-id-value")
-        val hc = HeaderCarrier(requestId = Some(requestId))
 
         stubFor(
           post(urlEqualTo(url))
             .withRequestBody(equalToJson(Json.toJson(model).toString))
-            .withHeader("correlationId", equalTo(requestId.value))
+            .withHeader("correlationId", matching(correlationIdRegex))
             .withHeader(HeaderNames.authorisation, equalTo(hipAuthToken))
             .willReturn(
               aResponse()
                 .withStatus(INTERNAL_SERVER_ERROR)
-                .withHeader("correlationId", requestId.value)
                 .withBody(Json.toJson(ErrorBodyModel("100001", "")).toString)
             )
         )
 
-        val result = connector.createIncomeSource(nino, model)(hc).futureValue
+        val result = connector.createIncomeSource(nino, model).futureValue
 
         result.left.value.status shouldBe 500
       }
 
       "return when the error message cannot be parsed" in {
-        val requestId = RequestId("request-id-value")
-        val hc = HeaderCarrier(requestId = Some(requestId))
 
         stubFor(
           post(urlEqualTo(url))
             .withRequestBody(equalToJson(Json.toJson(model).toString))
-            .withHeader("correlationId", equalTo(requestId.value))
+            .withHeader("correlationId", matching(correlationIdRegex))
             .withHeader(HeaderNames.authorisation, equalTo(hipAuthToken))
             .willReturn(
               aResponse()
                 .withStatus(INTERNAL_SERVER_ERROR)
-                .withHeader("correlationId", requestId.value)
                 .withBody(Json.obj("key" -> "value").toString)
             )
         )
 
-        val result = connector.createIncomeSource(nino, model)(hc).futureValue
+        val result = connector.createIncomeSource(nino, model).futureValue
 
         result.left.value.status shouldBe 500
       }
@@ -185,23 +173,20 @@ class CreateIncomeSourcesConnectorISpec
 
     "when the response status is not an expected value" - {
       "return an error" in {
-        val requestId = RequestId("request-id-value")
-        val hc = HeaderCarrier(requestId = Some(requestId))
 
         stubFor(
           post(urlEqualTo(url))
             .withRequestBody(equalToJson(Json.toJson(model).toString))
-            .withHeader("correlationId", equalTo(requestId.value))
+            .withHeader("correlationId", matching(correlationIdRegex))
             .withHeader(HeaderNames.authorisation, equalTo(hipAuthToken))
             .willReturn(
               aResponse()
                 .withStatus(IM_A_TEAPOT)
-                .withHeader("correlationId", requestId.value)
                 .withBody(Json.obj("key" -> "value").toString)
             )
         )
 
-        val result = connector.createIncomeSource(nino, model)(hc).futureValue
+        val result = connector.createIncomeSource(nino, model).futureValue
 
         result.left.value.status shouldBe 500
       }

--- a/test/models/ErrorBodyModelSpec.scala
+++ b/test/models/ErrorBodyModelSpec.scala
@@ -27,17 +27,30 @@ class ErrorBodyModelSpec extends TestSuite {
     "reason" -> "The service is currently unavailable"
   )
 
+  private val hipErrorBodyModelAsJson = Json.obj(
+    "type" -> "SERVICE_UNAVAILABLE",
+    "reason" -> "The service is currently unavailable"
+  )
+
   "ErrorBodyModel" should {
     val model = new ErrorBodyModel("SERVICE_UNAVAILABLE", "The service is currently unavailable")
 
     "serialize to Json" in {
-
       Json.toJson(model) mustBe errorBodyModelAsJson
     }
 
-    "deserialize from json without throwing a parse exception" in {
+    "for a DES/IF response" should {
 
-      errorBodyModelAsJson.as[ErrorBodyModel]
+      "deserialize from json without throwing a parse exception" in {
+        errorBodyModelAsJson.as[ErrorBodyModel]
+      }
+    }
+
+    "for a HIP response" should {
+
+      "deserialize from json without throwing a parse exception" in {
+        hipErrorBodyModelAsJson.as[ErrorBodyModel]
+      }
     }
   }
 


### PR DESCRIPTION
Added `authType` as application config, as I expect in Production this should be a "Bearer" token and not Basic auth. But Basic auth only seems to work in QA. 